### PR TITLE
Prevent logging code from ever failing

### DIFF
--- a/log/Logger.js
+++ b/log/Logger.js
@@ -5,7 +5,7 @@ const levels = logging.log4js.levels;
 
 let singleton = Symbol();
 let singletonEnforcer = Symbol();
-let userConfig;
+let userConfig = {};
 
 class Logger {
 
@@ -70,7 +70,7 @@ class Logger {
   }
 
   static config(config) {
-    userConfig = config;
+    userConfig = config || {};
   }
 
   //----------------------------------------------------
@@ -82,14 +82,9 @@ class Logger {
     logEntry.timestamp = moment().format(logging.timestampFormat);
     const level = logEntry.level.toLowerCase();
 
-    // Set user defined properties
-    if(!userConfig) {
-        throw new Error('Please set a user config object');
-    }
-
-    logEntry.microservice = userConfig.microservice;
-    logEntry.team = userConfig.team;
-    logEntry.environment = userConfig.environment;
+    logEntry.microservice = userConfig.microservice || 'not-configured';
+    logEntry.team = userConfig.team || 'not-configured';
+    logEntry.environment = userConfig.environment || 'not-configured';
 
     if (logging.output === outputTypes.single) {
       this.logger[level](JSON.stringify(logEntry));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/nodejs-logging",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "Logger.js",
   "scripts": {

--- a/test/unit/loggerTest.js
+++ b/test/unit/loggerTest.js
@@ -28,10 +28,10 @@ describe('Logging within the Node.js application', () => {
       myLogger.config(undefined);
     });
 
-    it('should throw an Error', () => {
+    it('should never throw an Error', () => {
       expect(() => {
         logger.info({});
-      }).to.throw(Error, 'Please set a user config object');
+      }).to.not.throw;
     });
 
   });


### PR DESCRIPTION
This pull request prevents the logging library from throwing if the user hasn't set a config object.

I'm making this assumption for two reasons:

* **Logging code should never break functionality**
    In the previous setup, not setting config would cause the logging code to break functionality. A misconfigured logger is an annoyance, not a world breaking issue.
* **Packages shouldn't configure the logger**
    I have a package that acts as a client for our IDAM. It needs to log. It can't however give this config as it's going to be used by many services and many teams. So the app that requires this library will have to configure the logger and the client library will use that config. This means that the logger can't break if it isn't configured yet as it won't be in my client libraries unit tests.