### PR TITLE
Suppress logging during tests

### DIFF
--- a/log/Logger.js
+++ b/log/Logger.js
@@ -86,12 +86,14 @@ class Logger {
     logEntry.team = userConfig.team || 'not-configured';
     logEntry.environment = userConfig.environment || 'not-configured';
 
-    if (logging.output === outputTypes.single) {
-      this.logger[level](JSON.stringify(logEntry));
-    } else if (logging.output === outputTypes.multi) {
-      this.logger[level](logEntry);
-    } else {
-      this.logger[level](`${logEntry.timestamp} ${logEntry.level} ${this.logger.category}: ${logEntry.message}`)
+    if (process.env.NODE_ENV != 'test') {
+      if (logging.output === outputTypes.single) {
+        this.logger[level](JSON.stringify(logEntry));
+      } else if (logging.output === outputTypes.multi) {
+        this.logger[level](logEntry);
+      } else {
+        this.logger[level](`${logEntry.timestamp} ${logEntry.level} ${this.logger.category}: ${logEntry.message}`)
+      }
     }
 
     return logEntry;

--- a/log/config.js
+++ b/log/config.js
@@ -46,7 +46,7 @@ const logging = {
   //      log4js - log levels
   //  ---------------------------------------
   //  ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF
-  currentLevel: process.env.LOG_LEVEL || log4js.levels.INFO,
+  currentLevel: process.env.NODE_ENV || log4js.levels.INFO,
 
   // "single": view JSON logs on a single line - this setting should be used for production.
   // "multi": view JSON logs over multiple lines - helpful during development.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "Logger.js",
   "scripts": {
-    "test": "LOG_LEVEL=OFF mocha test/unit/* --reporter spec"
+    "test": "NODE_ENV=test mocha test/unit/* --reporter spec"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request modifies the loggers behaviour to not output if `NODE_ENV` is test. In this repos tests it was explicitly setting `LOG_LEVEL=OFF` in it's tests to enable this functionality. 